### PR TITLE
Add login server to whitelist (Fixes #3)

### DIFF
--- a/whitelist.js
+++ b/whitelist.js
@@ -27,7 +27,8 @@ const whitelist = [
   "spclient.wg.spotify.com", // ads/tracking (blocked in blacklist), radio, recently played, friend activity,...
   "t.scdn.co", // background images
   "thisis-images.scdn.co", // 'this is' playlists images
-  "video-fa.scdn.co" // videos
+  "video-fa.scdn.co", // videos
+  "login5.spotify.com" // seems to be uk login server
 ];
 
 module.exports = whitelist;


### PR DESCRIPTION
**After some researching this problem appeared only while using Spotify with UK VPN.** 
Whitelisting `login5.spotify.com` helped to solve #3 

